### PR TITLE
Improve post search and clean up styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -18,4 +18,3 @@ button.selected {
     color: black;
     font-weight: bold;
 }
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,24 +1,31 @@
 {{ define "index.html" }}
 <h2>Последние посты</h2>
 
-<h3>Фильтр по категориям</h3>
-<form method="GET" action="/filter/category" class="mb-3">
-  {{ range .Categories }}
-    <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="id" value="{{ .ID }}" {{ if (inSlice $.Selected (printf "%d" .ID)) }}checked{{ end }}>
-      <label class="form-check-label">{{ .Name }}</label>
+<form method="GET" action="/" id="searchForm" class="d-flex align-items-start mb-3">
+  <input class="form-control me-2" type="search" name="q" placeholder="Поиск" value="{{ .Query }}">
+  <div class="dropdown me-2">
+    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="categoryDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+      Категория
+    </button>
+    <div class="dropdown-menu p-3" aria-labelledby="categoryDropdown" style="min-width: 200px;">
+      {{ range .Categories }}
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="category" value="{{ .ID }}" {{ if (inSlice $.Selected (printf "%d" .ID)) }}checked{{ end }}>
+          <label class="form-check-label">{{ .Name }}</label>
+        </div>
+      {{ end }}
+      <div class="mt-2">
+        <button class="btn btn-primary btn-sm" type="submit">Применить</button>
+        <a href="/" class="btn btn-link btn-sm">Сбросить</a>
+      </div>
     </div>
-  {{ end }}
-  <button class="btn btn-primary btn-sm" type="submit">Применить</button>
-  {{ if .Selected }}
-    <a href="/" class="ms-2">Сбросить фильтр</a>
-  {{ end }}
+  </div>
+  <button class="btn btn-outline-success" type="submit">Поиск</button>
 </form>
-<hr>
 
 <form action="{{ if .LikedView }}/{{ else }}/filter/liked{{ end }}" method="get" class="mb-3">
   <button class="btn btn-outline-primary btn-sm {{ if .LikedView }}selected{{ end }}" type="submit" name="liked" value="1">
-    Понравившиеся
+    Избранное
   </button>
 </form>
 
@@ -42,7 +49,7 @@
       <footer class="post-footer">
         <div class="mb-2">
           {{ range .Categories }}
-            <a class="badge bg-secondary text-decoration-none me-1" href="/filter/category?id={{ .ID }}">{{ .Name }}</a>
+            <a class="badge bg-secondary text-decoration-none me-1" href="/?category={{ .ID }}">{{ .Name }}</a>
           {{ end }}
         </div>
         <span class="me-2">👍 {{ .Likes }}</span>


### PR DESCRIPTION
## Summary
- revert custom font and dark mode toggle
- add search support in post handler
- implement search + category dropdown UI
- rename liked posts filter to Избранное

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684c667013e8832cb397a10794af46b2